### PR TITLE
content: add Slack AI bot CI/CD article (en + ko)

### DIFF
--- a/_data/medium_articles.yml
+++ b/_data/medium_articles.yml
@@ -3,6 +3,24 @@
 
 # 2026
 
+- title: "Building an AI Data Analysis Bot for Slack — CI/CD Environment"
+  date: "2026-04-30"
+  url: "https://joshua-data.medium.com/ai-agent-ci-cd-environment-en-a1ba1d588cf1"
+  tags:
+    - ai-llm
+    - data-engineering
+    - analytics-engineering
+  language: en
+
+- title: "슬랙 AI 데이터 분석봇 개발기 — CI/CD 환경 구축"
+  date: "2026-04-30"
+  url: "https://joshua-data.medium.com/ai-agent-ci-cd-environment-ko-29ecac6fff50"
+  tags:
+    - ai-llm
+    - data-engineering
+    - analytics-engineering
+  language: ko
+
 - title: "12 Areas Where Data Teams Should Adopt Agentic AI"
   date: "2026-04-21"
   url: "https://joshua-data.medium.com/12-areas-to-adopt-agentic-ai-en-6ecd93670683"


### PR DESCRIPTION
  ## Summary
  - Adds new Medium article (2026-04-30) to `_data/medium_articles.yml` — English + Korean versions
  - Tags: `ai-llm`, `data-engineering`, `analytics-engineering`

  ## Test plan
  - [ ] `/tags/` shows updated counts (Total 123, EN 35, KO 88, Medium 92)
  - [ ] Both new entries appear at the top of the blog list and link out to Medium

  🤖 Generated with [Claude Code](https://claude.com/claude-code)