### PR TITLE
style(post): tighten body and blockquote sizing for readability

### DIFF
--- a/_sass/_pages/_post.scss
+++ b/_sass/_pages/_post.scss
@@ -93,12 +93,8 @@
 
   &__content {
     font-size: $font-size-base;
-    line-height: 1.8;
+    line-height: 1.7;
     color: var(--color-text-secondary);
-
-    @include md {
-      font-size: $font-size-lg;
-    }
 
     // Typography for content
     h1, h2, h3, h4, h5, h6 {
@@ -161,12 +157,14 @@
     }
 
     blockquote {
-      margin: var(--space-xl) 0;
-      padding: var(--space-lg) var(--space-xl);
+      margin: var(--space-lg) 0;
+      padding: var(--space-md) var(--space-lg);
       background: var(--color-bg-secondary);
       border-left: 4px solid var(--color-accent);
       border-radius: 0 var(--radius-md) var(--radius-md) 0;
       font-style: italic;
+      font-size: $font-size-sm;
+      line-height: 1.6;
       color: var(--color-text-secondary);
 
       p:last-child {


### PR DESCRIPTION
  ## Summary
  - Drop the desktop `$font-size-lg` bump on `.post__content` so body stays at base size (16–18px) instead of jumping to 18–22px on `md`+ screens, and tighten `line-height` 1.8 → 1.7.                                    
  - Compact blockquote: padding `lg/xl` → `md/lg`, margin `xl` → `lg`, explicit `$font-size-sm` + `line-height: 1.6` so `>` quotes no longer eat a full paragraph of vertical space.                                     
  - Scope limited to `_sass/_pages/_post.scss` — headings, home, tags untouched.                                                                                                                                           
                                                                                                                                                                                                                           
  ## Test plan                                                                                                                                                                                                             
  - [ ] `bundle exec jekyll serve` and visually verify a long post (e.g. `/2025/08/16/identifying-and-modeling-sessions/`) reads tighter at desktop width.                                                                 
  - [ ] Open a post containing a `>` blockquote and confirm it sits smaller than body text and is more compact.                                                                                                            
  - [ ] Resize across mobile / tablet / desktop — no font-size jump at the `md` breakpoint.                                                                                                                                
  - [ ] Toggle dark mode and confirm blockquote background/border contrast still works. 